### PR TITLE
Remove 'sponsor-expo-ends' from schedule

### DIFF
--- a/public/schedule/index.ejs
+++ b/public/schedule/index.ejs
@@ -22,7 +22,7 @@
                  </tr>
                  <tr>
                    <td><b>1:00pm</b></td>
-                   <td>Opening Ceremonys begins and Sponsor Expo ends</td>
+                   <td>Opening Ceremonys begins</td>
                  </tr>
                  <tr>
                    <td><b>1:45pm</b></td>

--- a/public/schedule/index.ejs
+++ b/public/schedule/index.ejs
@@ -22,7 +22,7 @@
                  </tr>
                  <tr>
                    <td><b>1:00pm</b></td>
-                   <td>Opening Ceremonys begins</td>
+                   <td>Opening Ceremonies begins</td>
                  </tr>
                  <tr>
                    <td><b>1:45pm</b></td>


### PR DESCRIPTION
This is just a minor nitpick I have. No big deal but I already had the repo up so I figured why not