### PR TITLE
Bump revolutionuc-emails version to v2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "mongoose": "^4.7.7",
     "morgan": "^1.7.0",
     "multer": "^1.3.0",
-    "revolutionuc-emails": "github:revolutionuc/revolutionuc-emails#v2.0.0"
+    "revolutionuc-emails": "github:revolutionuc/revolutionuc-emails#v2.0.1"
   },
   "devDependencies": {
     "chai": "^3.5.0",


### PR DESCRIPTION
@domfarolino and team,

A few updates in v2.0.1 of [revolutionuc-emails](https://github.com/revolutionUC/revolutionuc-emails):

- Update master template (master.njk)
  - Use the `<preview>` tag only when a shortDescription is given
    (MailChimp appends it's own description, so this tag is needed
     only for transactional emails)
  - Update styling on button - add more top and bottom margin
- Add simple registration open template
- Various typo fixes (thanks @snyderks, @domfarolino, and @koreyhuskonen)