### PR TITLE
Update registration.js to use schoolOther field

### DIFF
--- a/lib/api/registration.js
+++ b/lib/api/registration.js
@@ -53,8 +53,8 @@ const registrantScheme = mongoose.Schema({
     required: true
   },
   schoolOther: {
-    type: Boolean,
-    default: false
+    type: String,
+    default: "off"
   },
   major: {
     type: String,

--- a/lib/api/registration.js
+++ b/lib/api/registration.js
@@ -52,6 +52,10 @@ const registrantScheme = mongoose.Schema({
     type: String,
     required: true
   },
+  schoolOther: {
+    type: Boolean,
+    default: false
+  },
   major: {
     type: String,
     required: true


### PR DESCRIPTION
To be used for https://github.com/RevolutionUC/revolutionuc-frontend/pull/46.

In the event that a students' school is not listed, the checkbox named 'schoolOther' is passed to the api with value `on`. If the checkbox isn't switched on, then it's passed with value `off` (also, interestingly, if the checkbox is never toggled, a value is never sent).

This way, we know if the user entered in a school that wasn't listed.

I messed up the first time so you'll probably want to squash this before merge 😄 